### PR TITLE
Fix ;gudgitters command for unrated CF users

### DIFF
--- a/tle/cogs/handles.py
+++ b/tle/cogs/handles.py
@@ -210,7 +210,7 @@ def get_gudgitters_image(rankings):
     y += LINE_HEIGHT*HEADER_SPACING
 
     for i, (pos, name, handle, rating, score) in enumerate(rankings):
-        color = rating_to_color(rating)
+        color = rating_to_color(rating if rating else 800)
         draw_bg(y, i%2)
         draw_row(str(pos+1), f'{name} ({rating if rating else "N/A"})', handle, str(score), color, y)
         if rating and rating >= 3000:  # nutella


### PR DESCRIPTION
### Fix
Default to gray color when the user is unrated


Error logs before applying this code fix:
```py
Mar 15 04:01:32 discord-bots run.sh[311688]: 15-03-2022 04:01:32:ERROR:tle.util.discord_common:Ignoring exception in command gudgitters:
Mar 15 04:01:32 discord-bots run.sh[311688]: Traceback (most recent call last):
Mar 15 04:01:32 discord-bots run.sh[311688]:   File "/root/.cache/pypoetry/virtualenvs/tle-P7XyH7Ao-py3.8/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
Mar 15 04:01:32 discord-bots run.sh[311688]:     ret = await coro(*args, **kwargs)
Mar 15 04:01:32 discord-bots run.sh[311688]:   File "/home/orendon/discord/TLE-fork/tle/cogs/handles.py", line 778, in gudgitters
Mar 15 04:01:32 discord-bots run.sh[311688]:     discord_file = get_gudgitters_image(rankings)
Mar 15 04:01:32 discord-bots run.sh[311688]:   File "/home/orendon/discord/TLE-fork/tle/cogs/handles.py", line 216, in get_gudgitters_image
Mar 15 04:01:32 discord-bots run.sh[311688]:     draw_row(str(pos+1), f'{name} ({rating if rating else "N/A"})', handle, str(score), color, y)
Mar 15 04:01:32 discord-bots run.sh[311688]:   File "/home/orendon/discord/TLE-fork/tle/cogs/handles.py", line 186, in draw_row
Mar 15 04:01:32 discord-bots run.sh[311688]:     context.set_source_rgb(*[x/255.0 for x in color])
Mar 15 04:01:32 discord-bots run.sh[311688]: TypeError: 'NoneType' object is not iterable
Mar 15 04:01:32 discord-bots run.sh[311688]: The above exception was the direct cause of the following exception:
Mar 15 04:01:32 discord-bots run.sh[311688]: Traceback (most recent call last):
Mar 15 04:01:32 discord-bots run.sh[311688]:   File "/root/.cache/pypoetry/virtualenvs/tle-P7XyH7Ao-py3.8/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 903, in invoke
Mar 15 04:01:32 discord-bots run.sh[311688]:     await ctx.command.invoke(ctx)
Mar 15 04:01:32 discord-bots run.sh[311688]:   File "/root/.cache/pypoetry/virtualenvs/tle-P7XyH7Ao-py3.8/lib/python3.8/site-packages/discord/ext/commands/core.py", line 859, in invoke
Mar 15 04:01:32 discord-bots run.sh[311688]:     await injected(*ctx.args, **ctx.kwargs)
Mar 15 04:01:32 discord-bots run.sh[311688]:   File "/root/.cache/pypoetry/virtualenvs/tle-P7XyH7Ao-py3.8/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
Mar 15 04:01:32 discord-bots run.sh[311688]:     raise CommandInvokeError(exc) from exc
Mar 15 04:01:32 discord-bots run.sh[311688]: discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: 'NoneType' object is not iterable
```